### PR TITLE
chore: Fix CI Upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  vr: kohirens/version-release@5.0.4
+  vr: kohirens/version-release@5.0.5
 
 parameters:
   ctx_auto_release:


### PR DESCRIPTION
Upgraded to Kohirens AVR 5.0.4 broke the auto release. Upgraded to 5.0.5 to fix the issue.