### PR TITLE
Patch 2025 09 05 02

### DIFF
--- a/session/message.go
+++ b/session/message.go
@@ -24,9 +24,15 @@ var stderr = struct {
 }
 
 var stdout = struct {
+	CurrentTime,
+	ExtendTime,
 	IDSet,
+	IDUpdate,
 	Restored string
 }{
-	IDSet:    "setting a session ID cookie now",
-	Restored: "session restored",
+	CurrentTime: "session current time %v",
+	ExtendTime:  "session extended time %v",
+	IDSet:       "setting a session ID cookie now",
+	IDUpdate:    "setting a session ID cookie now",
+	Restored:    "session restored",
 }

--- a/session/mongodb/session.go
+++ b/session/mongodb/session.go
@@ -3,7 +3,6 @@ package mongodb
 import (
 	"context"
 	"fmt"
-	"github.com/kohirens/www/session"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -18,8 +17,8 @@ func NewStorageMongoDB(c *mongo.Client, database, collection string) *StorageDoc
 	}
 }
 
-func (sd *StorageDocument) Save(data *session.Data) error {
-	query := map[string][]byte{"session_id": []byte(data.Id)}
+func (sd *StorageDocument) Save(name string, data []byte) error {
+	query := map[string][]byte{"session_id": []byte(name)}
 
 	_, e1 := UpsertOne(
 		query,

--- a/session/session.go
+++ b/session/session.go
@@ -27,10 +27,10 @@ type Data struct {
 type Storage interface {
 	// Load The session from storage.
 	// No matter the storage medium this should always return JSON as a byte array.
-	Load(id string) (*Data, error)
+	Load(id string) ([]byte, error)
 
 	// Save The session data to the storage medium.
-	Save(data *Data) error
+	Save(id string, data []byte) error
 }
 
 // Store Model for short term storage in memory (not intended for long
@@ -56,15 +56,15 @@ func GenerateID() string {
 }
 
 // NewManager Initialize a new session manager to handle session save, restore, get, and set.
-func NewManager(storage Storage, expiration time.Duration) *Manager {
-	store := make(Store, 100)
+func NewManager(storage Storage, location string, expiration time.Duration) *Manager {
 	return &Manager{
 		data: &Data{
 			GenerateID(),
 			time.Now().UTC().Add(expiration),
-			store,
+			make(Store, 100),
 		},
 		storage:    storage,
 		hasUpdates: false,
+		location:   location,
 	}
 }

--- a/session/sss/README.md
+++ b/session/sss/README.md
@@ -1,3 +1,35 @@
-# S3
+# SSS
 
-An S3 toolbox for general development task.
+Amazon Simple Storage Service (S3) for HTTP Session handling.
+
+It uses RAM to store/retrieve data, only when you call Load or Save does
+it send data across the network. This should provide good performance for the
+average HTTP session use case.
+
+However, if your storing large amounts of data then this may not be performant
+for your use case.
+
+
+Example:
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/kohirens/www/session"
+	"github.com/kohirens/www/session/sss"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+//  to store session data.
+sessionHandler := sss.NewStorageClient(bucket, context.Background())
+// set where to store the session in the bucket.
+sessionHandler.Prefix(sessionPrefix)
+// HTTP Session handler using RAM and then saving to  Amazon S3 for longer-term.
+sessionManager := session.NewManager(sessionHandler, sessionTimeout)
+```

--- a/session/sss/s3_test.go
+++ b/session/sss/s3_test.go
@@ -26,7 +26,7 @@ func ExampleNewStorageClient() {
 	sessionStorage.Prefix("session/")
 	// HTTP Session handler using RAM and then saving to Amazon S3 for
 	// longer-term.
-	sessionManager := session.NewManager(sessionStorage, time.Minute*20)
+	sessionManager := session.NewManager(sessionStorage, "", time.Minute*20)
 
 	type Counter struct {
 		Visits int // Only public fields will be saved to the session.

--- a/session/sss/session_test.go
+++ b/session/sss/session_test.go
@@ -1,0 +1,84 @@
+package sss
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/kohirens/stdlib/logger"
+	"github.com/kohirens/www/session"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+func ExampleNewStorageClient() {
+	bucket := os.Getenv("S3_BUCKET_NAME")
+	if bucket == "" {
+		panic("missing environment variable S3_BUCKET_NAME")
+	}
+
+	log := logger.Standard{}
+
+	// Start a new S3 storage client, it picks up its credential from the environment.
+	sessionStorage := NewStorageClient(bucket, context.Background())
+	// set where to store the session in the bucket.
+	sessionStorage.Prefix("session/")
+	// HTTP Session handler using RAM and then saving to Amazon S3 for
+	// longer-term.
+	sessionManager := session.NewManager(sessionStorage, time.Minute*20)
+
+	type Counter struct {
+		Visits int // Only public fields will be saved to the session.
+	}
+
+	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		counter := &Counter{}
+
+		// Load any previous session data.
+		sessionManager.Load(w, req)
+
+		// Convert the data into something your application can use.
+		jsonData := sessionManager.Get("counter")
+		if jsonData != nil {
+			if e := json.Unmarshal(jsonData, counter); e != nil {
+				panic("failed to unmarshal client info: " + e.Error())
+			}
+		}
+
+		counter.Visits++
+		_, e1 := w.Write([]byte(`{"count": "` + strconv.Itoa(counter.Visits) + `"}`))
+		if e1 != nil {
+			log.Errf(e1.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		bytes, e2 := json.Marshal(counter)
+		if e2 != nil {
+			log.Errf(e2.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// Save data to the session.
+		sessionManager.Set("counter", bytes)
+
+		// Write the session to Amazon S3.
+		if e := sessionManager.Save(); e != nil {
+			log.Errf(e.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// One can use generate_cert.go in crypto/tls to generate cert.pem and key.pem.
+	fmt.Printf("About to listen on 8443. Go to https://127.0.0.1:8443/")
+	err := http.ListenAndServeTLS(":8443", "cert.pem", "key.pem", nil)
+	if err != nil {
+		log.Errf(err.Error())
+	}
+}


### PR DESCRIPTION
## Changed Session Package API

Store no longer uses *session.Data as input parameter, instead it uses
primitive types []byte. This makes the API cleaner and adaptable to
any storage backend.

## BREAKING CHANGE

The Store interface has changed. All implementations of Store need to be
updated to reflect the new method signatures.

Verified stability and correctness of session management.