### PR TITLE
Fixed Backend Templates Variable Values

### DIFF
--- a/backend/template.go
+++ b/backend/template.go
@@ -14,16 +14,16 @@ type Renderer struct {
 	store    storage.Storage
 	location string
 	suffix   string
-	Vars     map[string]string
+	Vars     map[string]any
 }
 
 type TemplateManager interface {
 	// AddVar Add an item to the variable map.
-	AddVar(k, v string)
+	AddVar(k string, v any)
 	// AppendVars Appends a map to the Renderer.Vars map.
 	//
 	//	NOTE: When a key matches an existing key it will overwrite its value.
-	AppendVars(vars map[string]string)
+	AppendVars(vars map[string]any)
 	// Load A template, but it will not render it, instead, the template.Template
 	// object is returned so that you can render it when you want.
 	Load(name string) (*template.Template, error)
@@ -34,15 +34,15 @@ type TemplateManager interface {
 	// in string placeholders. Nothing more complex is supported at this time.
 	// Also, remember that maps are by default passed by reference, so there is
 	// no need to pass vars as a pointer.
-	Render(name string, w io.Writer, vars map[string]string) error
+	Render(name string, w io.Writer, vars map[string]any) error
 	// RenderFiles Parse multiple templates that produces the desired output.
 	//
 	//	This uses LoadFiles which in turn uses template.ParseFiles,
 	//	see https://pkg.go.dev/text/template#ParseFiles.
-	RenderFiles(w io.Writer, vars map[string]string, names ...string) (*template.Template, error)
+	RenderFiles(w io.Writer, vars map[string]any, names ...string) (*template.Template, error)
 }
 
-type Variables map[string]string
+type Variables map[string]any
 
 const ps = string(os.PathSeparator)
 
@@ -51,19 +51,19 @@ func NewTemplateManager(store storage.Storage, location, suffix string) Template
 		location: location,
 		store:    store,
 		suffix:   suffix,
-		Vars:     make(map[string]string),
+		Vars:     make(map[string]any),
 	}
 }
 
 // AddVar Add an item to the variable map.
-func (m *Renderer) AddVar(k, v string) {
+func (m *Renderer) AddVar(k string, v any) {
 	m.Vars[k] = v
 }
 
 // AppendVars Appends a map to the Renderer.Vars map.
 //
 //	NOTE: When a key matches an existing key it will overwrite its value.
-func (m *Renderer) AppendVars(vars map[string]string) {
+func (m *Renderer) AppendVars(vars map[string]any) {
 	maps.Copy(m.Vars, vars)
 }
 
@@ -115,7 +115,7 @@ func (m *Renderer) LoadFiles(names ...string) (*template.Template, error) {
 // in string placeholders. Nothing more complex is supported at this time.
 // Also, remember that maps are by default passed by reference, so there is
 // no need to pass vars as a pointer.
-func (m *Renderer) Render(name string, w io.Writer, vars map[string]string) error {
+func (m *Renderer) Render(name string, w io.Writer, vars map[string]interface{}) error {
 	t, e1 := m.Load(name)
 	if e1 != nil {
 		return e1
@@ -133,7 +133,7 @@ func (m *Renderer) Render(name string, w io.Writer, vars map[string]string) erro
 //
 //	This uses LoadFiles which in turn uses template.ParseFiles,
 //	see https://pkg.go.dev/text/template#ParseFiles.
-func (m *Renderer) RenderFiles(w io.Writer, vars map[string]string, names ...string) (*template.Template, error) {
+func (m *Renderer) RenderFiles(w io.Writer, vars map[string]interface{}, names ...string) (*template.Template, error) {
 	t, e1 := m.LoadFiles(names...)
 	if e1 != nil {
 		return nil, e1


### PR DESCRIPTION
Can now be any type instead of just a string.

It previously only allowed template variables to have a string value. The original intension was never meant to limit it to just this type, it was an oversite is all. This corrects that withtou introducing a break in the API. Though just strings are safter; this allows a greater depth and removes undue limitation to allow complex Templates. While you MUST stay vigilent with security, that should go without saying.