### PR TITLE
Fixed!: Auto Release Configuration

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version -%}
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_start_matches(pat="v") }}]
 {% else -%}
     ## [Unreleased]
 {% endif -%}
@@ -53,7 +53,7 @@ filter_unconventional = true
 split_commits = false
 # regex for parsing and grouping commits
 commit_parsers = [
-  { message = "^add(\\(.*\\))?:", group = "Added" },
+  { message = "^(add|feat)(\\(.*\\))?:", group = "Added" },
   { message = "^chg(\\(.*\\))?:", group = "Changed" },
   { message = "^dep(\\(.*\\))?:", group = "Deprecated" },
   { message = "^doc(\\(.*\\))?:", group = "Documentation" },
@@ -62,10 +62,10 @@ commit_parsers = [
   { message = "^sec(\\(.*\\))?:", group = "Security" },
   { message = "^style(\\(.*\\))?:", group = "Styling" },
   { message = "^test(\\(.*\\))?:", group = "Testing" },
-  { message = "^chore(\\(.*\\))?:", group = "Miscellaneous Tasks" },
+  { message = "^chore(\\(.*\\))?:", group = "Regular Maintenance" },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
-protect_breaking_commits = false
+protect_breaking_commits = true
 # filter out the commits that are not matched by commit parsers
 filter_commits = true
 # regex for matching git tags


### PR DESCRIPTION
Updated the Auto Release configuration which uses Git-Cliff. This newer version should work correctly with Kohirens Auto Version Release. Currently it skips breaking changes.