### PR TITLE
auto: Release 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1]
+
+### Fixed
+
+- Nil Error in AWS Lambda Package
+- AWS Lambda Cookie Retrieval Functionality
+
 ## [3.1.0]
 
 ### Added


### PR DESCRIPTION
## [3.1.1]

### Fixed

- Nil Error in AWS Lambda Package
- AWS Lambda Cookie Retrieval Functionality


changes sha256 o/I9Dg/TQ9viWuM88EhCoz4nymP8y0VPTsfSF6l440g=