### PR TITLE
Changed: Session Manager and Error Handling

### DIFF
--- a/backend/api.go
+++ b/backend/api.go
@@ -139,9 +139,7 @@ func (a *Api) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rawPath := r.URL.Path
 	Log.Infof("request %v %v", r.Method, rawPath)
 
-	idCookie, _ := r.Cookie(session.IDKey)
-
-	if e := a.RestoreSessionData(w, idCookie); e != nil {
+	if e := a.RestoreSessionData(w, r); e != nil {
 		Log.Errf("%v", e.Error())
 		w.WriteHeader(http.StatusInternalServerError)
 	}
@@ -216,8 +214,7 @@ func (a *Api) ServeLambda(event *awslambda.Input) (*awslambda.Output, error) {
 	}
 
 	Log.Infof("request %v %v", method, rawPath)
-	idCookie, _ := event.Cookie(session.IDKey)
-	if e := a.RestoreSessionData(w, idCookie); e != nil {
+	if e := a.RestoreSessionData(w, r); e != nil {
 		Log.Errf("%v", e.Error())
 		w.WriteHeader(http.StatusInternalServerError)
 		return w, nil
@@ -242,13 +239,25 @@ func (a *Api) ServeLambda(event *awslambda.Input) (*awslambda.Output, error) {
 	return w, nil
 }
 
-func (a *Api) RestoreSessionData(w http.ResponseWriter, idCookie *http.Cookie) error {
+func (a *Api) RestoreSessionData(w http.ResponseWriter, r *http.Request) error {
 	sm, e1 := a.Session()
 	if e1 != nil {
 		return e1
 	}
 
-	sm.Load(w, idCookie)
+	if e := sm.LoadFromCookie(r); e != nil {
+		Log.Dbugf("%v", e.Error())
+		// Set session cookie only when there is no session.
+		if errors.Is(e, session.NoSessionError{}) {
+			sm.SetCookie(w, r)
+		}
+		if errors.Is(e, session.ExpiredError{}) {
+			sm.Reset()
+			// then redirect to the login page.
+			w.Header().Set("Location", "/")
+			w.WriteHeader(http.StatusSeeOther)
+		}
+	}
 
 	// TODO pull from the cookie which provider the client chose.
 	gp, e2 := a.authManager.Get(KeyGoogleProvider)

--- a/session/error.go
+++ b/session/error.go
@@ -22,3 +22,19 @@ type NoSessionError struct {
 func (e NoSessionError) Error() string {
 	return "no session"
 }
+
+type RestoreError struct {
+	msg string
+}
+
+func (e RestoreError) Error() string {
+	return "failed to restore session " + e.msg
+}
+
+type InvalidIDError struct {
+	id string
+}
+
+func (e InvalidIDError) Error() string {
+	return "invalid session id " + e.id
+}

--- a/session/manager.go
+++ b/session/manager.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -19,6 +20,7 @@ type Manager struct {
 	hasUpdates bool
 	location   string
 	mutex      sync.Mutex
+	expiration time.Duration
 }
 
 // Get Retrieve data from the session.
@@ -79,68 +81,34 @@ func (m *Manager) IDCookie(cookiePath, domain string) *http.Cookie {
 	return c
 }
 
-// Load Will begin a new session, or restore an unexpired session, store the
-// session ID in an HTTP cookie to use on the next request.
-// Deprecated in favor of Reload, this has a lot of side effects that are not
-// necessary.
-func (m *Manager) Load(w http.ResponseWriter, idCookie *http.Cookie) {
-	// ONLY set a new cookie when there is no session, or it has expired.
-	if idCookie == nil {
+// LoadFromCookie will load a session from an HTTP cookie.
+func (m *Manager) LoadFromCookie(r *http.Request) error {
+	idCookie, e1 := r.Cookie(IDKey)
+
+	if errors.Is(e1, http.ErrNoCookie) || idCookie == nil {
 		idCookie = m.IDCookie(IDCookiePath, IDCookieDomain)
 		Log.Infof("%v", stdout.IDSet)
-		http.SetCookie(w, idCookie)
-		return
-	}
-
-	if e := m.Restore(idCookie.Value); e != nil {
-		Log.Errf("%v", e.Error())
-	} else { // Rolling session technique.
-		// When we successfully restore a session, we extend it a bit.
-		// Have the cookie also reflect this extended time.
-		Log.Infof("%v", stdout.Restored)
-
-		// NOTE: Seems setting only the expiration time for a cookie in Go can a new cookie under
-		// a path that the cookie was set on. This is not the intended action. We need complete replace it and
-		// set the desired time.
-		idCookie = m.IDCookie(IDCookiePath, IDCookieDomain)
-
-		// When we restore we also extend the life of the session.
-		// Update the session expiration time to match the session.
-		// when we do this does it send the cookie with the update or de we need to also set it in the response again?
-		idCookie.Expires = m.Expiration()
-		// set the cookie so that the update takes effect.
-		// locally this may work, but I'm not sure about in lambda/cloudfront world.
-		// Update the cookie with the new time.
-		// For clarity on updating HTTP Cookies, please see
-		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#creating_removing_and_updating_cookies
-		// or review https://datatracker.ietf.org/doc/html/rfc6265
-		http.SetCookie(w, idCookie)
-	}
-
-	// TODO: Validate the session ID is valid by looking it up in storage,
-	// if so, then also compare the browser data for a match, if not,
-	// then expire the cookie immediately (tampering).
-	if idCookie.Value != m.ID() {
-		Log.Errf("%v", stderr.SessionStrange)
-		idCookie.Expires = time.Now().UTC()
-		m.RemoveAll()
-	}
-}
-
-// Reload Will begin a new session, or restore an unexpired session, store the
-// session ID in an HTTP cookie to use on the next request.
-func (m *Manager) Reload(w http.ResponseWriter, r *http.Request) error {
-	idCookie, _ := r.Cookie(IDKey)
-	if idCookie == nil {
-		// no session to restore
 		return NoSessionError{}
 	}
 
 	if e := m.Restore(idCookie.Value); e != nil {
-		return e
+		Log.Errf("%v", e.Error())
+		return RestoreError{e.Error()}
 	}
 
-	Log.Infof("%v", stdout.Restored)
+	// Verify the session ID in the cookie matches the actual  valid by looking it up in storage,
+	// if so, then also compare the browser data for a match, if not,
+	// then expire the cookie immediately (tampering).
+	if idCookie.Value != m.ID() {
+		Log.Errf("%v", stderr.SessionStrange)
+		m.RemoveAll()
+		return InvalidIDError{idCookie.Value}
+	}
+
+	// Indicate the session has expired.
+	if time.Now().UTC().After(m.data.Expiration.UTC()) {
+		return ExpiredError{m.data.Expiration}
+	}
 
 	return nil
 }
@@ -167,6 +135,11 @@ func (m *Manager) RemoveAll() {
 	m.data.Items = Store{}
 }
 
+// Reset When you need to scrub the data from the session and fast.
+func (m *Manager) Reset() {
+	m.data = newData(m.expiration)
+}
+
 // Restore Restores the session by ID as a string.
 func (m *Manager) Restore(id string) error {
 	// Validate ID by a regex (see https://stackoverflow.com/questions/136505/searching-for-uuids-in-text-with-regex).
@@ -191,12 +164,9 @@ func (m *Manager) Restore(id string) error {
 		return fmt.Errorf(stderr.DecodeJSON, e.Error())
 	}
 
-	// Verify the session has not expired.
-	if time.Now().UTC().After(data.Expiration.UTC()) {
-		return ExpiredError{data.Expiration}
-	}
-
 	m.data = data
+
+	Log.Infof("%v", stdout.Restored)
 
 	return nil
 }
@@ -227,7 +197,14 @@ func (m *Manager) Set(key string, value []byte) {
 }
 
 // SetCookie stored the session ID in a secure HTTP cookie.
-func (m *Manager) SetCookie(w http.ResponseWriter) {
+//
+//	This is no-op if the cookie has been previously set and the session has not
+//	expired or the cookie deleted.
+func (m *Manager) SetCookie(w http.ResponseWriter, r *http.Request) {
+	if idCookie, _ := r.Cookie(IDKey); idCookie != nil && idCookie.Value == m.ID() {
+		return
+	}
+
 	idCookie := m.IDCookie(IDCookiePath, IDCookieDomain)
 	Log.Infof("%v", stdout.IDSet)
 	http.SetCookie(w, idCookie)

--- a/session/manager_test.go
+++ b/session/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
@@ -77,6 +78,7 @@ func (ms *MockStorage) Load(id string) ([]byte, error) {
 			"9e934ad9-cf7a-4ab9-b8aa-9e619b30badb",
 			time.Now().Add(time.Minute + 5), //exp.Format("2006-01-02T15:04:05Z07:00"),
 			Store{"test2": []byte("54321")},
+			false,
 		}
 		b, e := json.Marshal(sd)
 		if e != nil {
@@ -118,6 +120,7 @@ func TestManager_SetSessionIDCookie(t *testing.T) {
 		md            *MockStorage2
 		cookieCount   int
 		cookiePattern string
+		wantErr       bool
 	}{
 		{
 			"id-set",
@@ -126,6 +129,75 @@ func TestManager_SetSessionIDCookie(t *testing.T) {
 			&MockStorage2{Store{}},
 			1,
 			"_sid_",
+			true,
+		},
+		{
+			"set-only-once",
+			&MockResponse{},
+			&http.Cookie{
+				Name:     "_sid_",
+				Value:    "10d18518-3d9b-4af8-bcd3-3823ed03ed28",
+				Quoted:   false,
+				Path:     "/",
+				Expires:  mkTime01,
+				Secure:   true,
+				HttpOnly: true,
+				SameSite: http.SameSiteStrictMode,
+			},
+			&MockStorage2{Store{}},
+			0,
+			"_sid_",
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewManager(tt.md, "", time.Minute*3)
+			r := httptest.NewRequest("GET", "/", nil)
+			if tt.r != nil {
+				r.AddCookie(tt.r)
+			}
+
+			_ = m.LoadFromCookie(r)
+			m.SetCookie(tt.w, r)
+
+			// Do NOT use w.Header().Get it will only get the first index of the header.
+			cookies := tt.w.Header()["Set-Cookie"]
+			gotCount := 0
+			for _, cookie := range cookies {
+				gotCount += strings.Count(cookie, tt.cookiePattern)
+			}
+			if gotCount != tt.cookieCount {
+				t.Errorf("Manager.SetSessionIDCookie() = %v times, want %v", gotCount, tt.cookieCount)
+				return
+			}
+		})
+	}
+}
+
+func TestManager_LoadFromCookie(t *testing.T) {
+	mkTime01, _ := time.Parse(
+		"Mon, 02 Jan 2006 15:01:05 MST",
+		"Sun, 02 Mar 2025 14:18:16 GMT",
+	)
+	tests := []struct {
+		name          string
+		w             http.ResponseWriter
+		r             *http.Cookie
+		md            *MockStorage2
+		cookieCount   int
+		cookiePattern string
+		wantErr       bool
+	}{
+		{
+			"id-set",
+			&MockResponse{},
+			nil,
+			&MockStorage2{Store{}},
+			1,
+			"_sid_",
+			true,
 		},
 		{
 			"set-only-once",
@@ -143,22 +215,21 @@ func TestManager_SetSessionIDCookie(t *testing.T) {
 			&MockStorage2{Store{}},
 			1,
 			"_sid_",
+			false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := NewManager(tt.md, "", time.Minute*3)
-			m.Load(tt.w, tt.r)
-
-			// Do NOT use w.Header().Get it will only get the first index of the header.
-			cookies := tt.w.Header()["Set-Cookie"]
-			gotCount := 0
-			for _, cookie := range cookies {
-				gotCount += strings.Count(cookie, tt.cookiePattern)
+			r := httptest.NewRequest("GET", "/", nil)
+			if tt.r != nil {
+				r.AddCookie(tt.r)
 			}
-			if gotCount != tt.cookieCount {
-				t.Errorf("Manager.SetSessionIDCookie() = %v times, want %v", gotCount, tt.cookieCount)
+			e := m.LoadFromCookie(r)
+
+			if e != nil != tt.wantErr {
+				t.Errorf("Manager.LoadFromCookie() = %v, wantErr %v", e, tt.wantErr)
 				return
 			}
 		})
@@ -230,6 +301,7 @@ func (ms *MockStorage2) Load(id string) ([]byte, error) {
 			"10d18518-3d9b-4af8-bcd3-3823ed03ed28",
 			time.Now().Add(time.Minute + 5), //exp.Format("2006-01-02T15:04:05Z07:00"),
 			ms.data,
+			false,
 		}
 		b, e := json.Marshal(sd)
 		if e != nil {

--- a/session/session.go
+++ b/session/session.go
@@ -19,6 +19,7 @@ type Data struct {
 	Id         string    `json,bson:"session_id"`
 	Expiration time.Time `json,bson:"expiration"`
 	Items      Store     `json,bson:"session_data"`
+	CookieSet  bool      `json,bson:"cookie_set"`
 }
 
 // Storage An interface medium for storing the session data to anyplace an
@@ -71,13 +72,19 @@ func GenerateID() string {
 // NewManager Initialize a new session manager to handle session save, restore, get, and set.
 func NewManager(storage Storage, location string, expiration time.Duration) *Manager {
 	return &Manager{
-		data: &Data{
-			GenerateID(),
-			time.Now().UTC().Add(expiration),
-			make(Store, 100),
-		},
+		data:       newData(expiration),
 		storage:    storage,
 		hasUpdates: false,
 		location:   location,
+		expiration: expiration, // Store it for use with Reset method.
+	}
+}
+
+func newData(expiration time.Duration) *Data {
+	return &Data{
+		GenerateID(),
+		time.Now().UTC().Add(expiration),
+		make(Store, 100),
+		false,
 	}
 }


### PR DESCRIPTION
The session manager API was change by removing Reload and Load methods. They have been replaced by LoadFromCookie which returns several errors that indicate there is no existing session or it has expired. This should allow more flexible handling of sessions by the end user.

BREAKING CHANGE: The session manager API has been changed. The Reload and Load methods have been removed and replaced by LoadFromCookie, which returns specific errors. This requires updates to existing code that uses the session manager API.